### PR TITLE
Add base react-admin props to amplify components.

### DIFF
--- a/src/components/AmplifyAdmin.tsx
+++ b/src/components/AmplifyAdmin.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Admin } from "react-admin";
 import { buildAuthProvider, buildDataProvider } from "../providers";
 import { Operations } from "../providers/DataProvider";
+import { AdminProps } from "ra-core";
 
 export interface AmplifyAdminOptions {
   authGroups?: string[];
@@ -16,7 +17,7 @@ const defaultOptions: AmplifyAdminOptions = {
 export const AmplifyAdmin: React.FC<{
   operations: Operations;
   options?: AmplifyAdminOptions;
-}> = ({ children, operations, options = defaultOptions, ...propsRest }) => {
+} & Omit<AdminProps, "dataProvider">> = ({ children, operations, options = defaultOptions, ...propsRest }) => {
   const optionsBag = { ...defaultOptions, ...options };
   const { authGroups, storageBucket, storageRegion } = optionsBag;
 

--- a/src/components/AmplifyFileField.tsx
+++ b/src/components/AmplifyFileField.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FileField } from "react-admin";
+import { FileFieldProps } from "ra-ui-materialui/lib/field/FileField";
 import { useStorageField } from "../hooks/useStorageField";
 
 type Props = {
@@ -8,7 +9,7 @@ type Props = {
   storageOptions?: any;
 };
 
-export const AmplifyFileField: React.FC<Props> = ({
+export const AmplifyFileField: React.FC<Props & FileFieldProps> = ({
   source,
   record = {},
   storageOptions = {},

--- a/src/components/AmplifyFileInput.tsx
+++ b/src/components/AmplifyFileInput.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FileInput } from "react-admin";
+import { FileInput, InputProps } from "react-admin";
 import { useStorageInput } from "../hooks/useStorageInput";
 import { AmplifyFileField } from "./AmplifyFileField";
 
@@ -10,7 +10,7 @@ type Props = {
   storageOptions?: any;
 };
 
-export const AmplifyFileInput: React.FC<Props> = ({
+export const AmplifyFileInput: React.FC<Props & InputProps> = ({
   options = {},
   storageOptions = {},
   ...props

--- a/src/components/AmplifyFilter.tsx
+++ b/src/components/AmplifyFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Filter } from "react-admin";
+import { Filter, FilterProps } from "react-admin";
 
 interface Keys {
   [index: string]: {
@@ -65,7 +65,7 @@ function getKeys(filters: React.ReactNodeArray): Keys {
 export const AmplifyFilter: React.FC<{
   defaultQuery: string;
   setQuery?: React.Dispatch<string>;
-}> = ({ children, defaultQuery, setQuery = null, ...propsRest }) => {
+} & FilterProps> = ({ children, defaultQuery, setQuery = null, ...propsRest }) => {
   let filters;
 
   if (children !== null && typeof children === "object") {

--- a/src/components/AmplifyImageField.tsx
+++ b/src/components/AmplifyImageField.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ImageField } from "react-admin";
+import { ImageField, ImageFieldProps } from "react-admin";
 import { useStorageField } from "../hooks/useStorageField";
 
 type Props = {
@@ -8,7 +8,7 @@ type Props = {
   storageOptions?: any;
 };
 
-export const AmplifyImageField: React.FC<Props> = ({
+export const AmplifyImageField: React.FC<Props & ImageFieldProps> = ({
   source,
   record = {},
   storageOptions = {},

--- a/src/components/AmplifyImageInput.tsx
+++ b/src/components/AmplifyImageInput.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { ImageInput } from "react-admin";
+import { ImageInput, InputProps } from "react-admin";
+import { FileInputOptions, FileInputProps } from "ra-ui-materialui/lib/input/FileInput";
 import { useStorageInput } from "../hooks/useStorageInput";
 import { AmplifyImageField } from "./AmplifyImageField";
 
@@ -10,7 +11,7 @@ type Props = {
   storageOptions?: any;
 };
 
-export const AmplifyImageInput: React.FC<Props> = ({
+export const AmplifyImageInput: React.FC<Props & FileInputProps & InputProps<FileInputOptions>> = ({
   options = {},
   storageOptions = {},
   ...props

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,1 +1,0 @@
-declare module "react-admin";


### PR DESCRIPTION
Prop types for various components do not currently include props from the base elements they extend. For example AmplifyAdmin only includes operations/options props and does not expose base props from the base Admin component it extends. This PR removes types definition for react-admin module and uses Props defined in the base package.