### PR TITLE
Fix function getQueryName return value in DataProvider.ts

### DIFF
--- a/src/providers/DataProvider.ts
+++ b/src/providers/DataProvider.ts
@@ -333,7 +333,7 @@ export class DataProvider {
     }
     // else singular operations ["create", "delete", "get", "update"]
     return `${operation}${
-      resource.charAt(0).toUpperCase() + resource.slice(1, -1)
+      resource.charAt(0).toUpperCase() + resource.slice(1)
     }`;
   }
 


### PR DESCRIPTION
We are using the features that you have released. Thank you.

In the meantime, when calling the dataProvider.getOne function, sending "category" as a parameter was converted to "getCategor" and the query was not executed.

Therefore, after checking the cause, when returning from the getQueryName function, it determines that the slice range needs to be modified and requests a pull.